### PR TITLE
Added Career Compensation Resources and CSC 171/3

### DIFF
--- a/Academics/CSC 171/ReadMe.MD
+++ b/Academics/CSC 171/ReadMe.MD
@@ -5,3 +5,15 @@
 
  #### Please make sure that using these resources doesn't conflict with Academic Honesty Policies. While CSUG will try not to provide any such resources, we will not be responsible for their usage. 
 ---
+# Why Study Java?
+[Code-Institute](https://codeinstitute.net/blog/what-is-java/)  
+
+# Java Tutorials
+[JavaTPoint](https://www.javatpoint.com/java-tutorial)  
+
+# Recursion Resources
+[GeeksForGeeks](https://www.geeksforgeeks.org/recursion/)  
+Intro to Recursion Video w/ Cracking the Coding Interview(https://www.youtube.com/watch?v=KEEKn7Me-ms)  
+
+# Collections
+[TutorialsPoint](https://www.tutorialspoint.com/java/java_collections.htm)  

--- a/Academics/CSC 173/ReadMe.MD
+++ b/Academics/CSC 173/ReadMe.MD
@@ -5,3 +5,27 @@
 
  #### Please make sure that using these resources doesn't conflict with Academic Honesty Policies. While CSUG will try not to provide any such resources, we will not be responsible for their usage. 
 ---
+
+## Finite Automata and Regular Expressions
+Regular Expressions (https://www.cs.rochester.edu/u/nelson/courses/csc_173/fa/re.html)  
+Graphic to Design Your Own DFA (http://madebyevan.com/fsm/)  
+
+## Grammars and Parsing
+
+## Turing Machines and Computability
+
+## Relational Algebra and Databases
+Relational Algebra (https://www.tutorialspoint.com/dbms/relational_algebra.htm)
+
+[SQL](https://www.sqltutorial.org)
+
+
+## Boolean Logic and Boolean Circuits
+[Karnaugh-Maps](https://www.youtube.com/watch?v=UfZKvPQku8w)
+
+
+
+
+
+
+

--- a/Jobs and Internship/ReadMe.md
+++ b/Jobs and Internship/ReadMe.md
@@ -14,6 +14,12 @@ For Contributors: Please try to add links from opportunities you're familiar wit
 |Facebook|SWE Intern|Various|All|[Facebook](https://www.facebook.com/careers/jobs/654496918442526/)|None|
 
 
+# Compensation Resources
+
+These are resources to gain insight into a company's compensation, benefit, promotion structure and interview experiences. Mainly applicable for full time offers.
+
+[Glassdoor] (https://www.glassdoor.com/member/home/index.htm)
+[Levels] (https://www.levels.fyi)
 
 
 

--- a/Jobs and Internship/ReadMe.md
+++ b/Jobs and Internship/ReadMe.md
@@ -18,8 +18,9 @@ For Contributors: Please try to add links from opportunities you're familiar wit
 
 These are resources to gain insight into a company's compensation, benefit, promotion structure and interview experiences. Mainly applicable for full time offers.
 
-[Glassdoor] (https://www.glassdoor.com/member/home/index.htm)  
-[Levels] (https://www.levels.fyi)
+[Glassdoor](https://www.glassdoor.com/member/home/index.htm)  
+[Levels](https://www.levels.fyi)
+
 
 
 

--- a/Jobs and Internship/ReadMe.md
+++ b/Jobs and Internship/ReadMe.md
@@ -18,7 +18,7 @@ For Contributors: Please try to add links from opportunities you're familiar wit
 
 These are resources to gain insight into a company's compensation, benefit, promotion structure and interview experiences. Mainly applicable for full time offers.
 
-[Glassdoor] (https://www.glassdoor.com/member/home/index.htm)
+[Glassdoor] (https://www.glassdoor.com/member/home/index.htm) |
 [Levels] (https://www.levels.fyi)
 
 

--- a/Jobs and Internship/ReadMe.md
+++ b/Jobs and Internship/ReadMe.md
@@ -18,7 +18,7 @@ For Contributors: Please try to add links from opportunities you're familiar wit
 
 These are resources to gain insight into a company's compensation, benefit, promotion structure and interview experiences. Mainly applicable for full time offers.
 
-[Glassdoor] (https://www.glassdoor.com/member/home/index.htm) |
+[Glassdoor] (https://www.glassdoor.com/member/home/index.htm)  
 [Levels] (https://www.levels.fyi)
 
 


### PR DESCRIPTION
Added links to the most popular compensation sites, typically used by full-time Software engineers to negotiate and make decisions about their salaries. 